### PR TITLE
Update managed policies

### DIFF
--- a/Linux/managed.json
+++ b/Linux/managed.json
@@ -51,7 +51,6 @@
   "AutofillAddressEnabled": false,
   "AutofillCreditCardEnabled": false,
   "AutofillMembershipsEnabled": false,
-  "AutomaticHttpsDefault": 2,
   "BlockThirdPartyCookies": true,
   "BrowserCodeIntegritySetting": 2,
   "BrowserNetworkTimeQueriesEnabled": false,

--- a/macOS/Managed Preferences/com.microsoft.Edge.plist
+++ b/macOS/Managed Preferences/com.microsoft.Edge.plist
@@ -112,8 +112,6 @@
     <false />
     <key>AutofillMembershipsEnabled</key>
     <false />
-    <key>AutomaticHttpsDefault</key>
-    <integer>2</integer>
     <key>BlockThirdPartyCookies</key>
     <true />
     <key>BrowserCodeIntegritySetting</key>


### PR DESCRIPTION
commit e4ffc0d7287bb15e20059b469b3ddd48e4e43fad
Author: NarwhalPrince <102437580+NarwhalPrince@users.noreply.github.com>
Date:   Tue Jun 3 14:15:37 2025 -0500

    Update com.microsoft.Edge.plist

    Removed `AutomaticHttpsDefault` as it is marked as deprecated and breaks the display of edge://settings/privacy/securitySubPage

    https://learn.microsoft.com/en-us/DeployEdge/microsoft-edge-browser-policies/automatichttpsdefault

    It is replaced in Edge 139 with `HttpsUpgradesEnabled`

https://learn.microsoft.com/en-us/DeployEdge/microsoft-edge-browser-policies/httpsupgradesenabled

    Signed-off-by: NarwhalPrince <102437580+NarwhalPrince@users.noreply.github.com>